### PR TITLE
second implementation

### DIFF
--- a/MockNFCTag/AirTag.swift
+++ b/MockNFCTag/AirTag.swift
@@ -6,17 +6,19 @@
 //
 
 import Foundation
-import CoreNFC
 
+protocol MyNFCMiFareTag {
+  func sendMiFareCommand(commandPacket command: Data, resultHandler: @escaping (Result<Data, Error>) -> Void)
+}
 
 protocol CommandExecutor {
   
-  func write(data dataToWrite: Data, for tag: NFCMiFareTag) async -> Data
+  func write(data dataToWrite: Data, for tag: MyNFCMiFareTag) async -> Data
 }
 
 final class AirTag: CommandExecutor {
   
-  func write(data dataToWrite: Data, for tag: NFCMiFareTag) async -> Data {
+  func write(data dataToWrite: Data, for tag: MyNFCMiFareTag) async -> Data {
     let result = await withCheckedContinuation{ (continuation: CheckedContinuation<Data, Never>) in
       tag.sendMiFareCommand(commandPacket: dataToWrite) { result in
         // logic what I need to test

--- a/MockNFCTag/NFCTagWritter.swift
+++ b/MockNFCTag/NFCTagWritter.swift
@@ -27,6 +27,9 @@ final class TagReader: NSObject, NFCTagReaderSessionDelegate {
     case .miFare(let tag):
       // tag is NFCMiFare
       Task {
+        /// Test are working but now as the write function needs a MyNFCMiFareTag the code in production doesn't
+        /// I don't know how can I address this as `MyNFCMiFareTag` is a protocol and `NFCMiFareTag` as well,
+        /// I cannot make a protocol conform another protocol 🤷‍♂️
         let result = await airTag.write(data: Data(), for: tag)
       }
     default:

--- a/MockNFCTagTests/AirTagTest.swift
+++ b/MockNFCTagTests/AirTagTest.swift
@@ -14,7 +14,7 @@ final class AirTagTest: XCTestCase {
   
   func test_wirteData_shouldFinishSuccess() async {
     let sut = makeSUT()
-    let mockTag = NFCMiFareTagMock()
+    let mockTag = MyNFCMiFareTagMock()
     mockTag.commandResult = Data([0xFF])
     let data = Data([0xAA, 0x19])
     
@@ -35,7 +35,9 @@ final class AirTagTest: XCTestCase {
 }
 
 
-class NFCMiFareTagMock: NSObject, NFCMiFareTag {
+class MyNFCMiFareTagMock: MyNFCMiFareTag {
+
+  
   
   enum Message {
     case sendMiFareCommand
@@ -44,76 +46,9 @@ class NFCMiFareTagMock: NSObject, NFCMiFareTag {
   private(set) var messages = [Message]()
   var commandResult: Data!
   
-  func sendMiFareCommand(commandPacket command: Data, completionHandler: @escaping (Data, Error?) -> Void) {
-    completionHandler(commandResult, nil)
+  func sendMiFareCommand(commandPacket command: Data, resultHandler: @escaping (Result<Data, Error>) -> Void) {
+    resultHandler(.success(commandResult))
     messages.append(.sendMiFareCommand)
   }
-  
-  func sendMiFareISO7816Command(_ apdu: NFCISO7816APDU, completionHandler: @escaping (Data, UInt8, UInt8, Error?) -> Void) {
-    
-  }
-  
-  var mifareFamily: NFCMiFareFamily = .desfire
-  
-  var identifier: Data = Data()
-  
-  var historicalBytes: Data?
-  
-  var type: __NFCTagType = .miFare
-  
-  var session: NFCReaderSessionProtocol?
-  
-  var isAvailable: Bool = false
-  
-  func asNFCISO15693Tag() -> NFCISO15693Tag? {
-    nil
-  }
-  
-  func asNFCISO7816Tag() -> NFCISO7816Tag? {
-    nil
-  }
-  
-  func asNFCFeliCaTag() -> NFCFeliCaTag? {
-    nil
-  }
-  
-  func asNFCMiFareTag() -> NFCMiFareTag? {
-    nil
-  }
-  
-  func queryNDEFStatus(completionHandler: @escaping (NFCNDEFStatus, Int, Error?) -> Void) {
-    
-  }
-  
-  func readNDEF(completionHandler: @escaping (NFCNDEFMessage?, Error?) -> Void) {
-    
-  }
-  
-  func writeNDEF(_ ndefMessage: NFCNDEFMessage, completionHandler: @escaping (Error?) -> Void) {
-    
-  }
-  
-  func writeLock(completionHandler: @escaping (Error?) -> Void) {
-    
-  }
-  
-  static var supportsSecureCoding: Bool = false
-  
-  func copy(with zone: NSZone? = nil) -> Any {
-    Int()
-  }
-  
-  func encode(with coder: NSCoder) {
-    
-  }
-  
-  required init?(coder: NSCoder) {
-    
-  }
-  
-  override init() {
-    
-  }
-  
   
 }


### PR DESCRIPTION
- decoupling `AirTag` from `CoreNFC`
- Testing are passing, however, the production code is not compiling as the `NFCTagReaderSessionDelegate` return an `NFCMiFareTag` and the `AirTag.write` function requires a `MyNFCMiFareTag` and I cannot make that `NFCMiFareTag` conform `MyNFCMiFareTag` protocol because it is a protocol too